### PR TITLE
Optimize Cropping on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
+++ b/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
@@ -172,6 +172,10 @@ public class ImageEditorModule extends ReactContextBaseJavaModule {
       WritableMap result = Arguments.createMap();
       result.putInt("height", options.outHeight);
       result.putInt("width", options.outWidth);
+      Log.d("ImageEditor",
+              ".getImageDimensions[result]: { height: " + options.outHeight
+                      + ", width: " + options.outWidth
+      );
       jsPromise.resolve(result);
     } catch (java.io.IOException error) {
       jsPromise.reject("ImageEditor.getImageDimensions Bitmap decode error: ", error);
@@ -440,8 +444,8 @@ public class ImageEditorModule extends ReactContextBaseJavaModule {
       if (
           cropX == 0 &&
           cropY == 0 &&
-          cropWidth == bitmap.getWidth() &&
-          cropHeight == bitmap.getHeight()
+          almostEqual(cropWidth, bitmap.getWidth(), 1) &&
+          almostEqual(cropHeight, bitmap.getHeight(), 1)
       ) {
         Log.d("ImageEditor", "bitmap crop is not required, RETURNING not cropped bitmap");
         return bitmap;
@@ -559,6 +563,12 @@ public class ImageEditorModule extends ReactContextBaseJavaModule {
           externalCacheDir : internalCacheDir;
     }
     return File.createTempFile(TEMP_FILE_PREFIX, getFileExtensionForType(mimeType), cacheDir);
+  }
+
+  public static boolean almostEqual(double a, double b, double eps) {
+    Log.d("ImageEditor", "almostEqual(a: " + a + ", b: " + b + ", eps: " + eps);
+    Log.d("ImageEditor", "Math.abs(a-b) = " + Math.abs(a-b));
+    return Math.abs(a-b) <= eps;
   }
 
   // in pixels

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,8 @@ export type ImageCropData = {
   size: { width: number, height: number },
   /**
    * Size to scale the cropped image to.
+   * only works on iOS (and will be removed afterwards),
+   * defaults to 1280 for larger size on Android
    */
   displaySize: { width: number, height: number },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/image-editor",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "React Native Image Editing native modules for iOS & Android",
   "author": "Dawid Urbaniak <dawidu@onet.pl>",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/image-editor",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "React Native Image Editing native modules for iOS & Android",
   "author": "Dawid Urbaniak <dawidu@onet.pl>",
   "contributors": [],


### PR DESCRIPTION
# Merge with:
- https://github.com/oneclick-llc/looky-rn-gallery/pull/17
- https://github.com/oneclick-llc/rn-looky/pull/539

Part of [Looky-3768](https://oneclicklife.youtrack.cloud/issue/Looky-3768/Android-pri-popytke-opublikovat-neskolko-foto-bolshogo-razmera-prilozhenie-padaet)

## Android:
- remove displaySize/targetSize
- downscale (if needed) to target of 1280 on larger side
- recycle bitmap after use
- do not scale via Matrix
- do not recreate bitmap with rotation matrix if not required (do not create matrix if not used in first place)
- do not recreate bitmap with crop applied if cropping is not required
- add more debug logs